### PR TITLE
Create redirect from /league to specified url

### DIFF
--- a/mobileapp/lib/server.js
+++ b/mobileapp/lib/server.js
@@ -90,6 +90,10 @@ app.get('/', function(req, res){
   res.render("index", data);
 });
 
+app.get('/league', function(req, res) {
+  res.redirect("http://foosball.hq.axiosengineering.com:5984/digitalfoosball/_design/league/_rewrite/");
+})
+
 app.get("/dialog", function(req, res) {
   res.render("partials/dialog", data);
 });


### PR DESCRIPTION
Quick hard-link fix for now. There should be a way to get to get to the link without hard-coding it, or at least without hard-coding the port and the http://foosball.hq.axiosengineering.com, but this will work for now. The league/ and mobileapp/ (which is really the main app) are weirdly separate, so there's not a lot of crossover/I don't think doing `req.redirect(':' + port + '/whatever/')` will work.
